### PR TITLE
Security: GitHub Actions pinnen op volledige commit-SHA

### DIFF
--- a/.github/workflows/check_project.yml
+++ b/.github/workflows/check_project.yml
@@ -14,4 +14,4 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: inbo/actions/check_project@main
+      - uses: inbo/actions/check_project@5ad8ad6a75c216b77713aa14ebaef30d76ee1463 # main

--- a/.github/workflows/quarto_branch.yml
+++ b/.github/workflows/quarto_branch.yml
@@ -16,4 +16,4 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: inbo/actions/render_quarto@devel
+      - uses: inbo/actions/render_quarto@55098124f283c4f9b9402d43ec4a9382ee05c105 # devel

--- a/.github/workflows/quarto_main.yml
+++ b/.github/workflows/quarto_main.yml
@@ -15,4 +15,4 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: inbo/actions/render_quarto@devel
+      - uses: inbo/actions/render_quarto@55098124f283c4f9b9402d43ec4a9382ee05c105 # devel


### PR DESCRIPTION
_Onderdeel van een INBO-brede security-hardening: SHA-pinning van GitHub Actions. Aanbevolen door o.a. [GitHub Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)._